### PR TITLE
Support page and global generators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: flake8
         args: [--max-line-length=88]
-        language_version: python3.7
+        language_version: python3
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.7.0

--- a/README.md
+++ b/README.md
@@ -55,6 +55,42 @@ This will yield the following result (with the notmyidea theme):
 
 ![figure](avatar-example.png)
 
+Page templates work in a similar way:
+
+```html
+{% if page.author_avatar %}
+<div align="center">
+        <img src="{{ page.author_avatar }}">
+</div>
+{% endif %}
+```
+
+To use in common templates, such as `base.html`, you can do something like this:
+
+```html
+{% if author_avatar %}
+<div align="center">
+        <img src="{{ author_avatar }}">
+</div>
+{% endif %}
+```
+
+Or if you want to support optional overriding of the email in articles or pages,
+while still taking the global configuration if neither is available:
+
+```html
+{% if article and article.author_avatar %}
+  {% set author_avatar = article.author_avatar %}
+{% elif page and page.author_avatar %}
+  {% set author_avatar = page.author_avatar %}
+{% endif %}
+{% if author_avatar %}
+<div align="center">
+        <img src="{{ author_avatar }}">
+</div>
+{% endif %}
+```
+
 Configuration
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 pelican = "^4.5"
+libgravatar = "^0.2.5"
+py3dns = "^3.2"
+pylibravatar = "1.7"
 markdown = {version = "^3.2.2", optional = true}
 
 [tool.poetry.dev-dependencies]
@@ -38,11 +41,8 @@ flake8 = "^3.8"
 flake8-black = "^0.2.0"
 invoke = "^1.3"
 isort = "^5.4"
-libgravatar = "^0.2.5"
 livereload = "^2.6"
 markdown = "^3.2.2"
-py3dns = "^3.2"
-pylibravatar = "1.7"
 pytest = "^6.0"
 pytest-cov = "^2.8"
 pytest-pythonpath = "^0.7.3"


### PR DESCRIPTION
Here I've added support for page generators, as well as insertion into the global context so that the global setting is available on pages like index, categories, etc. I also expanded the tests to cover testing the insertion into the global context. The README says the setting is `AVATAR_AUTHOR_EMAIL`, though the code previously said `AUTHOR_EMAIL`, which also seems to match the previous gravatar pelican plugin. I went with the "namespaced" setting here and updated the code to match the README since that seems like the safest option.

I included a few other little tweaks to help make the plugin run correctly in my usage which I think is also generally the right direction:

* Generalized the `language_version` in the pre-commit hook, since my system with Python 3.9 wouldn't run the hooks otherwise (and the same would bite anyone running Python 3.8)
* Moved the dependencies needed to run the plugin out of the "dev" section so that the (eventual) package install will pull in the required libraries.

While adding support for testing the global part of the plugin, I switched from the hardcoded base urls and URL regex with the reasoning that this isn't trying to test the output of those libraries, but rather the faithful transcription of the output of the libraries into the generated HTML files.